### PR TITLE
Mudanças no hover do ChannelButton

### DIFF
--- a/src/components/ChannelButton/styles.ts
+++ b/src/components/ChannelButton/styles.ts
@@ -33,6 +33,14 @@ export const Container = styled.div`
     > div span {
       color: var(--white);
     }
+
+    > div:not(:first-child) svg {
+      display: flex;
+    }
+  }
+
+  > div:not(:first-child) svg {
+    display: none;
   }
 `;
 


### PR DESCRIPTION
Acrescentando função onde os botões Settings e PersonAdd só aparecem quando o cursor do mouse passa por cima, assim como no discord original como foi sugerido no vídeo